### PR TITLE
Return string answers and validate bot responses

### DIFF
--- a/app/qa_engine.py
+++ b/app/qa_engine.py
@@ -65,4 +65,5 @@ class QAEngine:
         )
 
     def answer(self, query: str) -> str:
-        return self.qa_chain.invoke({"query": query})
+        result = self.qa_chain.invoke({"query": query})
+        return result["result"]

--- a/app/telegram_bot.py
+++ b/app/telegram_bot.py
@@ -10,6 +10,9 @@ async def handle_message(update: Update, context: ContextTypes.DEFAULT_TYPE):
     try:
         response = qa_engine.answer(user_input)
 
+        if not isinstance(response, str):
+            response = str(response)
+
         if len(response) > 4000:
             response = response[:4000] + "...\n\n🔹 Ответ был обрезан из-за длины."
 


### PR DESCRIPTION
## Summary
- Extract only the `result` text from `RetrievalQA` output
- Ensure Telegram bot checks response type before length limiting

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_689e345861288325b5a3c785af30797b