### PR TITLE
Add program-specific QA indexes and selection in Telegram bot

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -4,10 +4,12 @@ TELEGRAM_TOKEN = os.getenv("TELEGRAM_TOKEN")
 
 AI_PROGRAM_URL = "https://abit.itmo.ru/program/master/ai"
 AI_PRODUCT_PROGRAM_URL = "https://abit.itmo.ru/program/master/ai_product"
-PDF_URLS = [
-    "https://api.itmo.su/constructor-ep/api/v1/static/programs/10033/plan/abit/pdf",       # AI
-    "https://api.itmo.su/constructor-ep/api/v1/static/programs/10130/plan/abit/pdf",       # AI Product
-]
+
+# PDF-файлы учебных планов по программам
+PDF_URLS = {
+    "ai": "https://api.itmo.su/constructor-ep/api/v1/static/programs/10033/plan/abit/pdf",  # AI
+    "ai_product": "https://api.itmo.su/constructor-ep/api/v1/static/programs/10130/plan/abit/pdf",  # AI Product
+}
 
 CHUNK_SIZE = 1000
 CHUNK_OVERLAP = 200

--- a/app/qa_engine.py
+++ b/app/qa_engine.py
@@ -5,48 +5,38 @@ from langchain.chains import RetrievalQA
 from langchain.prompts import PromptTemplate
 from langchain_community.llms import HuggingFacePipeline
 from transformers import AutoTokenizer, AutoModelForSeq2SeqLM, pipeline
-import config, html_parser
+
+import config
+import html_parser
 
 
 class QAEngine:
-    def __init__(self):
+    """Два отдельных QA-движка для программ AI и AI Product."""
+
+    def __init__(self) -> None:
         print("🔄 Загружаю и обрабатываю учебные планы...")
-
-        documents = []
-        for url in config.PDF_URLS:
-            text = html_parser.fetch_pdf_text(url)
-            if text:
-                documents.append(text)
-
-        if not documents:
-            raise ValueError("❌ Не удалось загрузить ни одного учебного плана.")
 
         text_splitter = RecursiveCharacterTextSplitter(
             chunk_size=config.CHUNK_SIZE,
-            chunk_overlap=config.CHUNK_OVERLAP
+            chunk_overlap=config.CHUNK_OVERLAP,
         )
-        docs = text_splitter.create_documents(documents)
 
         print("📐 Создание эмбеддингов...")
         embedding_model = HuggingFaceEmbeddings(
             model_name="sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2"
         )
-        self.db = FAISS.from_documents(docs, embedding_model)
 
         print("🧠 Загрузка языковой модели cointegrated/rut5-base...")
         tokenizer = AutoTokenizer.from_pretrained("cointegrated/rut5-small")
         model = AutoModelForSeq2SeqLM.from_pretrained("cointegrated/rut5-small")
-
         pipe = pipeline(
             "text2text-generation",
             model=model,
             tokenizer=tokenizer,
             max_length=512,
-            do_sample=False
+            do_sample=False,
         )
         self.llm = HuggingFacePipeline(pipeline=pipe)
-
-        self.retriever = self.db.as_retriever(search_kwargs={"k": 3})
 
         self.prompt = PromptTemplate(
             template=(
@@ -54,15 +44,46 @@ class QAEngine:
                 "Вопрос:\n{question}\n\n"
                 "Ответ:"
             ),
-            input_variables=["context", "question"]
+            input_variables=["context", "question"],
         )
 
-        self.qa_chain = RetrievalQA.from_chain_type(
-            llm=self.llm,
-            retriever=self.retriever,
-            chain_type="refine",
-            chain_type_kwargs={"prompt": self.prompt}
+        # Создаём отдельные QA-цепочки для каждой программы
+        self.qa_chains = {}
+        for program, url in config.PDF_URLS.items():
+            text = html_parser.fetch_pdf_text(url)
+            if not text:
+                raise ValueError(f"❌ Не удалось загрузить учебный план: {url}")
+
+            docs = text_splitter.create_documents([text])
+            db = FAISS.from_documents(docs, embedding_model)
+            retriever = db.as_retriever(search_kwargs={"k": 3})
+            chain = RetrievalQA.from_chain_type(
+                llm=self.llm,
+                retriever=retriever,
+                chain_type="refine",
+                chain_type_kwargs={"prompt": self.prompt},
+            )
+            self.qa_chains[program] = chain
+
+    def _run_chain(self, query: str, program: str) -> str:
+        chain = self.qa_chains.get(program)
+        if not chain:
+            raise ValueError("Неизвестная программа")
+        result = chain.invoke({"query": query})
+        if isinstance(result, dict):
+            return result.get("result", "")
+        return result
+
+    def answer(self, query: str, program: str) -> str:
+        """Ответ для конкретной программы."""
+        return self._run_chain(query, program)
+
+    def compare(self, query: str) -> str:
+        """Сравнение ответов по обеим программам."""
+        ai_answer = self._run_chain(query, "ai")
+        ai_prod_answer = self._run_chain(query, "ai_product")
+        return (
+            f"Программа AI:\n{ai_answer}\n\n"
+            f"Программа AI Product:\n{ai_prod_answer}"
         )
 
-    def answer(self, query: str) -> str:
-        return self.qa_chain.invoke({"query": query})


### PR DESCRIPTION
## Summary
- Maintain separate vector indexes and QA chains for AI and AI Product programs
- Telegram bot now asks user to choose program and routes queries accordingly
- Add ability to compare answers across both programs

## Testing
- `python -m py_compile app/config.py app/qa_engine.py app/telegram_bot.py`


------
https://chatgpt.com/codex/tasks/task_e_689e34588e6c83258bcb1978d0eb6fe9