### PR TITLE
Parse course data from PDF

### DIFF
--- a/app/html_parser.py
+++ b/app/html_parser.py
@@ -1,6 +1,7 @@
 import requests
 import pdfplumber
 from io import BytesIO
+import re
 
 def fetch_pdf_text(url: str) -> str:
     print(f"📄 Загружаю PDF с {url}...")
@@ -21,3 +22,53 @@ def fetch_pdf_text(url: str) -> str:
     except Exception as e:
         print(f"❌ Ошибка загрузки PDF: {e}")
         return ''
+
+
+def parse_course_data(text: str) -> list[dict]:
+    """Парсит текст учебного плана в структуру данных.
+
+    Ожидается, что каждая строка текста может содержать название дисциплины,
+    упоминание семестра и признак обязательности. Функция извлекает эти данные
+    и возвращает их в виде списка словарей.
+
+    Пример возвращаемой структуры::
+
+        [
+            {
+                "discipline": "Математика",
+                "semester": 1,
+                "is_mandatory": True,
+            },
+            ...
+        ]
+
+    Поскольку формат исходных PDF может различаться, функция использует
+    простейшие эвристики: ищет в строке номер семестра и ключевое слово
+    «обязател» для определения обязательности.
+    """
+
+    courses = []
+    for raw_line in text.splitlines():
+        line = raw_line.strip()
+        if not line:
+            continue
+
+        sem_match = re.search(r"семестр\s*(\d+)", line, re.IGNORECASE)
+        if sem_match:
+            name = line[: sem_match.start()].strip(" -–")
+            is_mandatory = "обязател" in line.lower()
+
+            try:
+                semester = int(sem_match.group(1))
+            except ValueError:
+                continue
+
+            courses.append(
+                {
+                    "discipline": name,
+                    "semester": semester,
+                    "is_mandatory": is_mandatory,
+                }
+            )
+
+    return courses

--- a/app/qa_engine.py
+++ b/app/qa_engine.py
@@ -13,10 +13,14 @@ class QAEngine:
         print("🔄 Загружаю и обрабатываю учебные планы...")
 
         documents = []
+        self.course_data = []
         for url in config.PDF_URLS:
             text = html_parser.fetch_pdf_text(url)
             if text:
                 documents.append(text)
+                parsed = html_parser.parse_course_data(text)
+                if parsed:
+                    self.course_data.extend(parsed)
 
         if not documents:
             raise ValueError("❌ Не удалось загрузить ни одного учебного плана.")


### PR DESCRIPTION
## Summary
- parse PDF text into structured course data with discipline, semester, and mandatory flag
- store parsed course info inside QAEngine for later recommendation logic

## Testing
- `python -m py_compile app/html_parser.py app/qa_engine.py`


------
https://chatgpt.com/codex/tasks/task_e_689e34645bb08325812eebdfaa9dda16