### PR TITLE
Add skills prompt and elective recommendation module

### DIFF
--- a/app/recommendations.py
+++ b/app/recommendations.py
@@ -1,0 +1,42 @@
+"""Utility functions for recommending electives based on user skills."""
+
+from typing import List, Dict
+
+# Example study plan structure mapping skill keywords to electives
+STUDY_PLAN: Dict[str, List[str]] = {
+    "programming": ["Введение в Python", "Разработка веб-приложений"],
+    "data": ["Анализ данных", "Машинное обучение"],
+    "design": ["UX/UI дизайн", "Графический дизайн"],
+    "management": ["Проектный менеджмент", "Основы предпринимательства"],
+}
+
+
+def _parse_skills(skills_text: str) -> List[str]:
+    """Split user input into a list of lowercase skill keywords."""
+    return [s.strip().lower() for s in skills_text.split(",") if s.strip()]
+
+
+def match_skills_to_subjects(skills: List[str], plan: Dict[str, List[str]] | None = None) -> List[str]:
+    """Match user skills with subjects from the study plan."""
+    if plan is None:
+        plan = STUDY_PLAN
+
+    electives: List[str] = []
+    for skill in skills:
+        for keyword, subjects in plan.items():
+            if keyword in skill:
+                electives.extend(subjects)
+    # Remove duplicates while preserving order
+    seen = set()
+    unique_electives = []
+    for subj in electives:
+        if subj not in seen:
+            seen.add(subj)
+            unique_electives.append(subj)
+    return unique_electives
+
+
+def recommend_electives(skills_text: str) -> List[str]:
+    """Return a list of recommended electives based on user skills text."""
+    skills = _parse_skills(skills_text)
+    return match_skills_to_subjects(skills)

--- a/app/telegram_bot.py
+++ b/app/telegram_bot.py
@@ -2,11 +2,44 @@ import os
 from telegram import Update
 from telegram.ext import ApplicationBuilder, ContextTypes, MessageHandler, filters
 from qa_engine import QAEngine
+import recommendations
 
 qa_engine = QAEngine()
 
+
 async def handle_message(update: Update, context: ContextTypes.DEFAULT_TYPE):
     user_input = update.message.text
+    user_data = context.user_data
+
+    # Stage: ask for previous education or skills
+    if not user_data.get("skills") and not user_data.get("awaiting_skills"):
+        await update.message.reply_text(
+            "Расскажите о вашем предыдущем образовании или навыках."  # noqa: E501
+        )
+        user_data["awaiting_skills"] = True
+        return
+
+    # Stage: receive skills and give elective recommendations
+    if user_data.get("awaiting_skills"):
+        user_data["skills"] = user_input
+        user_data["awaiting_skills"] = False
+        electives = recommendations.recommend_electives(user_input)
+        if electives:
+            rec_text = "\n- ".join(electives)
+            await update.message.reply_text(
+                "На основе ваших навыков рекомендуем следующие элективы:\n- "
+                + rec_text
+            )
+        else:
+            await update.message.reply_text(
+                "Пока не могу подобрать элективы по указанным навыкам."
+            )
+        await update.message.reply_text(
+            "Теперь вы можете задать вопрос о программе или учебных планах."
+        )
+        return
+
+    # Regular QA handling once skills are known
     try:
         response = qa_engine.answer(user_input)
 
@@ -18,6 +51,7 @@ async def handle_message(update: Update, context: ContextTypes.DEFAULT_TYPE):
     except Exception as e:
         await update.message.reply_text("⚠️ Произошла ошибка. Попробуйте позже.")
         print(f"❌ Ошибка при обработке сообщения: {e}")
+
 
 def run_telegram_bot():
     app = ApplicationBuilder().token(os.getenv("TELEGRAM_TOKEN")).build()


### PR DESCRIPTION
## Summary
- Add dialogue step asking users about prior education or skills in Telegram bot
- Provide elective recommendations based on user skills via new `recommendations` module

## Testing
- `python -m py_compile app/telegram_bot.py app/recommendations.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689e346ce0fc83258c6357d660e1387f